### PR TITLE
Lower memory usage in swpm_members prepare_items()

### DIFF
--- a/simple-membership/classes/class.swpm-members.php
+++ b/simple-membership/classes/class.swpm-members.php
@@ -93,8 +93,12 @@ class SwpmMembers extends WP_List_Table {
 		global $wpdb;
 
 		$this->process_bulk_action();
-
-		$query  = 'SELECT * FROM ' . $wpdb->prefix . 'swpm_members_tbl';
+		
+		$records_query_head = 'SELECT member_id,user_name,first_name,last_name,email,alias,subscription_starts,account_state,last_accessed';
+		$count_query_head = 'SELECT COUNT(member_id)';
+		
+		$query = ' ';
+		$query .= ' FROM ' . $wpdb->prefix . 'swpm_members_tbl';
 		$query .= ' LEFT JOIN ' . $wpdb->prefix . 'swpm_membership_tbl';
 		$query .= ' ON ( membership_level = id ) ';
 
@@ -163,7 +167,7 @@ class SwpmMembers extends WP_List_Table {
 		$query           .= ' ORDER BY ' . $orderby . ' ' . $order;
 
 		//Execute the query
-		$totalitems = $wpdb->query( $query ); //return the total number of affected rows
+		$totalitems = $wpdb->get_var( $count_query_head.$query);
 		//Pagination setup
 		$perpage = apply_filters( 'swpm_members_menu_items_per_page', 50 );
 		$paged   = filter_input( INPUT_GET, 'paged' );
@@ -188,7 +192,7 @@ class SwpmMembers extends WP_List_Table {
 		$sortable = $this->get_sortable_columns();
 
 		$this->_column_headers = array( $columns, $hidden, $sortable );
-		$this->items           = $wpdb->get_results( $query, ARRAY_A );
+		$this->items           = $wpdb->get_results( $records_query_head.$query, ARRAY_A );
 	}
 
 	function get_user_count_by_account_state() {


### PR DESCRIPTION
prepare_items() was retrieving every field in the join of swpm_members and swpm_membership, but only needed a few fields. This is a heavy query being run twice and can exceed available memory when there are many members and category/page protections. Change to only retrieve a count in the first query, and only the required columns in the second limited/paginated query.